### PR TITLE
fix maven warning: 'groupId' contains an expression but should be a constant.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,24 +4,19 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
+  <groupId>cn.ucloud.us3</groupId>
+  <artifactId>us3-bigdata-adaptor</artifactId>
+  <version>1.4.2</version>
+
+  <name>us3-bigdata-adaptor</name>
+  <url>https://www.ucloud.cn/</url>
+
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <hadoop.version>2.8.5</hadoop.version>
-    <adaptor.version.major>1</adaptor.version.major>
-    <adaptor.version.minor>4</adaptor.version.minor>
-    <adaptor.version.patch>2</adaptor.version.patch>
-    <adaptor.version>${adaptor.version.major}.${adaptor.version.minor}.${adaptor.version.patch}</adaptor.version>
-    <adaptor.os.name>us3</adaptor.os.name>
   </properties>
-
-  <groupId>cn.ucloud.${adaptor.os.name}</groupId>
-  <artifactId>${adaptor.os.name}-bigdata-adaptor</artifactId>
-  <version>${hadoop.version}-${adaptor.version}</version>
-
-  <name>us3-bigdata-adaptor</name>
-  <url>https://www.ucloud.cn/</url>
 
   <dependencies>
     <dependency>
@@ -68,13 +63,11 @@
       <version>${hadoop.version}</version>
       <scope>provided</scope>
     </dependency>
-<dependency>
-  <groupId>cn.ucloud.ufile</groupId>
-  <artifactId>ufile-client-java</artifactId>
-  <version>2.6.7</version>
-</dependency>
-
-
+    <dependency>
+      <groupId>cn.ucloud.ufile</groupId>
+      <artifactId>ufile-client-java</artifactId>
+      <version>2.6.7</version>
+    </dependency>
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
@@ -84,6 +77,7 @@
   </dependencies>
 
   <build>
+    <finalName>${project.artifactId}-${hadoop.version}-${project.version}</finalName>
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>


### PR DESCRIPTION
fix these warnings:
```
[WARNING] Some problems were encountered while building the effective model for cn.ucloud.us3:us3-bigdata-adaptor:jar:2.8.5-1.4.2
[WARNING] 'groupId' contains an expression but should be a constant. @ cn.ucloud.${adaptor.os.name}:${adaptor.os.name}-bigdata-adaptor:${hadoop.version}-${adaptor.version}, /home/user/us3-bigdata-adaptor/pom.xml, line 19, column 12
[WARNING] 'artifactId' contains an expression but should be a constant. @ cn.ucloud.${adaptor.os.name}:${adaptor.os.name}-bigdata-adaptor:${hadoop.version}-${adaptor.version}, /home/user/us3-bigdata-adaptor/pom.xml, line 20, column 15
[WARNING] 'version' contains an expression but should be a constant. @ cn.ucloud.${adaptor.os.name}:${adaptor.os.name}-bigdata-adaptor:${hadoop.version}-${adaptor.version}, /home/user/us3-bigdata-adaptor/pom.xml, line 21, column 12
```